### PR TITLE
Fix Next.js build by adding Prisma adapter and tracked env defaults

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,67 @@
+# -----------------------------------------------------------------------------
+# Portfolio Backtester environment example
+# Copy this file to `.env` (and optionally to `app/.env.local`) and replace the
+# placeholder values with the credentials for your deployment target.
+# -----------------------------------------------------------------------------
+
+# ----- FastAPI service -------------------------------------------------------
+API_HOST=0.0.0.0
+API_PORT=8000
+API_LOG_LEVEL=info
+
+# Database credentials used by both FastAPI (SQLAlchemy) and Next.js (Prisma).
+# Prisma expects the canonical `postgresql://` form. The FastAPI layer will
+# automatically adapt this value to use the psycopg driver internally.
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_USER=portfolio
+POSTGRES_PASSWORD=portfolio
+POSTGRES_DB=portfolio
+# When running everything via Docker Compose, keep the host as `postgres`. For
+# direct hosting on a VM or bare metal, change it to wherever Postgres runs.
+DATABASE_URL=postgresql://portfolio:portfolio@postgres:5432/portfolio
+
+# Object storage for uploaded TradingView CSV files (MinIO or S3 compatible).
+S3_ENDPOINT_URL=http://minio:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=portfolio-uploads
+
+# Allowed browser origins for CORS when the API is served directly.
+# Multiple origins can be supplied as a comma-separated list.
+CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Portfolio sizing defaults and plan limits (adjust to taste).
+TOTAL_CAPITAL_DEFAULT=100000
+FREE_MAX_FILES=5
+PRO_MAX_FILES=25
+ENTERPRISE_MAX_FILES=100
+FREE_RUNS_PER_DAY=1
+PRO_RUNS_PER_DAY=20
+ENTERPRISE_RUNS_PER_DAY=1000
+
+# ----- Next.js / NextAuth authentication -------------------------------------
+NEXTAUTH_SECRET=please-change-me
+NEXTAUTH_URL=http://localhost:3000
+
+# OAuth providers (optional – enable the ones you use).
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_ID=
+GITHUB_SECRET=
+
+# SMTP provider for passwordless email login (optional).
+EMAIL_SERVER_HOST=
+EMAIL_SERVER_PORT=587
+EMAIL_SERVER_USER=
+EMAIL_SERVER_PASSWORD=
+EMAIL_FROM=no-reply@example.com
+
+# ----- Frontend ↔ Backend communication --------------------------------------
+# Used by the frontend to call the FastAPI service directly or through the
+# proxy route. When deploying behind HTTPS, update these to the public origin.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/
+FASTAPI_URL=http://localhost:8000
+
+# Base URL consumed by the Playwright smoke tests.
+E2E_BASE_URL=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,67 @@
+# -----------------------------------------------------------------------------
+# Portfolio Backtester environment example
+# Copy this file to `.env` (and optionally to `app/.env.local`) and replace the
+# placeholder values with the credentials for your deployment target.
+# -----------------------------------------------------------------------------
+
+# ----- FastAPI service -------------------------------------------------------
+API_HOST=0.0.0.0
+API_PORT=8000
+API_LOG_LEVEL=info
+
+# Database credentials used by both FastAPI (SQLAlchemy) and Next.js (Prisma).
+# Prisma expects the canonical `postgresql://` form. The FastAPI layer will
+# automatically adapt this value to use the psycopg driver internally.
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_USER=portfolio
+POSTGRES_PASSWORD=portfolio
+POSTGRES_DB=portfolio
+# When running everything via Docker Compose, keep the host as `postgres`. For
+# direct hosting on a VM or bare metal, change it to wherever Postgres runs.
+DATABASE_URL=postgresql://portfolio:portfolio@postgres:5432/portfolio
+
+# Object storage for uploaded TradingView CSV files (MinIO or S3 compatible).
+S3_ENDPOINT_URL=http://minio:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_BUCKET=portfolio-uploads
+
+# Allowed browser origins for CORS when the API is served directly.
+# Multiple origins can be supplied as a comma-separated list.
+CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Portfolio sizing defaults and plan limits (adjust to taste).
+TOTAL_CAPITAL_DEFAULT=100000
+FREE_MAX_FILES=5
+PRO_MAX_FILES=25
+ENTERPRISE_MAX_FILES=100
+FREE_RUNS_PER_DAY=1
+PRO_RUNS_PER_DAY=20
+ENTERPRISE_RUNS_PER_DAY=1000
+
+# ----- Next.js / NextAuth authentication -------------------------------------
+NEXTAUTH_SECRET=please-change-me
+NEXTAUTH_URL=http://localhost:3000
+
+# OAuth providers (optional – enable the ones you use).
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_ID=
+GITHUB_SECRET=
+
+# SMTP provider for passwordless email login (optional).
+EMAIL_SERVER_HOST=
+EMAIL_SERVER_PORT=587
+EMAIL_SERVER_USER=
+EMAIL_SERVER_PASSWORD=
+EMAIL_FROM=no-reply@example.com
+
+# ----- Frontend ↔ Backend communication --------------------------------------
+# Used by the frontend to call the FastAPI service directly or through the
+# proxy route. When deploying behind HTTPS, update these to the public origin.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/
+FASTAPI_URL=http://localhost:8000
+
+# Base URL consumed by the Playwright smoke tests.
+E2E_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,11 @@ app/node_modules
 # Python
 __pycache__/
 *.py[cod]
-.env
 .venv
 venv/
 .env.*
+!.env.example
+!app/.env.local.example
 
 # Data
 storage/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tests/      # Cross-cutting docs/tests (FastAPI + PyTest inside api/, Playwright
 
 ## Quickstart (Development)
 
-1. Copy `.env.example` to `.env` and adjust credentials for Postgres, MinIO, Stripe, and OAuth providers.
+1. Copy `.env.example` to `.env` (project root) and adjust the credentials for Postgres, MinIO, and any OAuth/email providers you plan to enable. For local Next.js development also copy it to `app/.env.local` so the frontend can read the same values.
 2. Install dependencies for the backend and frontend:
    ```bash
    cd api && pip install -e .[dev]
@@ -56,4 +56,19 @@ The stack exposes:
 - MinIO console: `http://localhost:9001` (credentials from `.env`)
 
 The Docker entrypoints automatically install dependencies, apply migrations (see `db/migrations`), and serve the production build.
+
+## Environment variables
+
+The project shares a single `.env` file for both the FastAPI backend and the Next.js frontend. The sample `.env.example` includes sensible defaults for local Docker Compose usage:
+
+| Variable | Purpose |
+| --- | --- |
+| `DATABASE_URL` | Postgres connection string used by Prisma and FastAPI (FastAPI automatically upgrades it to the `postgresql+psycopg://` form that SQLAlchemy requires). |
+| `S3_ENDPOINT_URL`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET` | Object storage configuration for uploaded TradingView CSVs (MinIO or AWS S3). |
+| `NEXTAUTH_SECRET`, `NEXTAUTH_URL` | Required for NextAuth session encryption and callback URL configuration. |
+| `GOOGLE_*`, `GITHUB_*` | Optional OAuth providers for social login. Leave blank to disable. |
+| `EMAIL_*` | SMTP credentials for passwordless email sign-in (optional). |
+| `NEXT_PUBLIC_API_BASE_URL`, `FASTAPI_URL` | URLs the frontend uses to talk to the FastAPI API. Update to match your deployment hostnames. |
+
+Copy `.env.example` to `.env` before running any of the services, and populate the placeholders with the credentials for your server. When running the Next.js dev server outside Docker, duplicate the file to `app/.env.local` (or export the variables in your shell) so that Prisma and NextAuth receive the same configuration. In that scenario the Postgres host should typically be `localhost` instead of the Docker service name `postgres`.
 

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Sequence
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -11,14 +12,17 @@ class Settings(BaseSettings):
     api_port: int = 8000
     api_log_level: str = "info"
 
-    database_url: str = "postgresql+psycopg://portfolio:portfolio@postgres:5432/portfolio"
+    database_url: str = "postgresql://portfolio:portfolio@postgres:5432/portfolio"
 
     s3_endpoint_url: str = "http://minio:9000"
     s3_access_key: str = "minioadmin"
     s3_secret_key: str = "minioadmin"
     s3_bucket: str = "portfolio-uploads"
 
-    cors_allow_origins: Sequence[str] = ("http://localhost:3000", "http://127.0.0.1:3000")
+    cors_allow_origins: Sequence[str] = (
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+    )
 
     total_capital_default: float = 100_000
 
@@ -28,6 +32,23 @@ class Settings(BaseSettings):
     free_runs_per_day: int = 1
     pro_runs_per_day: int = 20
     enterprise_runs_per_day: int = 1000
+
+    @property
+    def sqlalchemy_database_url(self) -> str:
+        """Return a SQLAlchemy-compatible DSN, coercing the driver if needed."""
+
+        if self.database_url.startswith("postgresql+psycopg"):
+            return self.database_url
+        if self.database_url.startswith("postgresql://"):
+            return self.database_url.replace("postgresql://", "postgresql+psycopg://", 1)
+        return self.database_url
+
+    @field_validator("cors_allow_origins", mode="before")
+    @classmethod
+    def _split_origins(cls, value: Sequence[str] | str) -> Sequence[str]:
+        if isinstance(value, str):
+            return tuple(origin.strip() for origin in value.split(",") if origin.strip())
+        return value
 
 
 @lru_cache

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -3,7 +3,11 @@ from sqlalchemy.orm import sessionmaker
 
 from .core.config import settings
 
-engine = create_engine(settings.database_url, future=True, pool_pre_ping=True)
+engine = create_engine(
+    settings.sqlalchemy_database_url,
+    future=True,
+    pool_pre_ping=True,
+)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
 
 

--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -1,0 +1,24 @@
+# Local development environment variables for the Next.js app.
+# Copy this file to `app/.env.local` when running `npm run dev` so that the
+# frontend has access to the same credentials that power the FastAPI backend.
+# Keep the values in sync with the project root `.env` file.
+
+# Point this to the Postgres host reachable from the Next.js process. When using
+# Docker Compose locally the database is exposed on localhost:5432.
+DATABASE_URL=postgresql://portfolio:portfolio@localhost:5432/portfolio
+NEXTAUTH_SECRET=please-change-me
+NEXTAUTH_URL=http://localhost:3000
+
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/
+FASTAPI_URL=http://localhost:8000
+
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_ID=
+GITHUB_SECRET=
+
+EMAIL_SERVER_HOST=
+EMAIL_SERVER_PORT=587
+EMAIL_SERVER_USER=
+EMAIL_SERVER_PASSWORD=
+EMAIL_FROM=no-reply@example.com

--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverActions: true,
-  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
+        "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.6.0",
         "@radix-ui/react-tabs": "^1.0.4",
         "@tanstack/react-query": "^5.28.4",
@@ -530,6 +531,16 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@next-auth/prisma-adapter": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-1.0.7.tgz",
+      "integrity": "sha512-Cdko4KfcmKjsyHFrWwZ//lfLUbcLqlyFqjd/nYE2m3aZ7tjMNUjpks47iw7NTCnXf+5UWz5Ypyt1dSs1EP5QJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3",
+        "next-auth": "^4"
+      }
     },
     "node_modules/@next/env": {
       "version": "14.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
+    "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.6.0",
     "@radix-ui/react-tabs": "^1.0.4",
     "@tanstack/react-query": "^5.28.4",
@@ -34,8 +35,8 @@
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.16",
-    "prisma": "^5.6.0",
     "postcss": "8.4.31",
+    "prisma": "^5.6.0",
     "tailwindcss": "3.3.5",
     "typescript": "5.2.2"
   }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,27 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node", "@types/node", "@types/react", "@types/react-dom", "@types/react"]
+    "types": [
+      "node",
+      "@types/node",
+      "@types/react",
+      "@types/react-dom",
+      "@types/react"
+    ],
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       context: ..
       dockerfile: infra/Dockerfile.api
     env_file:
-      - ../.env.example
+      - ../.env
     depends_on:
       - postgres
       - minio
@@ -41,7 +41,7 @@ services:
       context: ..
       dockerfile: infra/Dockerfile.web
     env_file:
-      - ../.env.example
+      - ../.env
     depends_on:
       - api
     environment:


### PR DESCRIPTION
## Summary
- add the @next-auth/prisma-adapter dependency so the Next.js build can resolve the adapter module
- drop the obsolete serverActions flag and accept Next.js' tsconfig additions to align with the current toolchain
- check in a default .env file and tweak .gitignore so new clones include baseline configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cefa2f884c8329bcfd713c0228a550