### PR TITLE
Implement marketing site and demo backtest flows

### DIFF
--- a/app/app/backtests/page.tsx
+++ b/app/app/backtests/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { mockBacktests } from "../../lib/mock-data";
+import { formatCurrency, formatPercent } from "../../lib/format";
+
+export default function BacktestsPage() {
+  const searchParams = useSearchParams();
+  const startDemoSelected = searchParams.get("demo") === "1";
+  const [query, setQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    startDemoSelected ? mockBacktests.slice(0, 2).map((run) => run.id) : []
+  );
+
+  const filtered = useMemo(() => {
+    const normalised = query.trim().toLowerCase();
+    if (!normalised) return mockBacktests;
+    return mockBacktests.filter((run) => {
+      const haystack = [run.name, run.strategy, run.symbols.join(" ")].join(" ").toLowerCase();
+      return haystack.includes(normalised);
+    });
+  }, [query]);
+
+  const selectedRuns = useMemo(
+    () => mockBacktests.filter((run) => selectedIds.includes(run.id)),
+    [selectedIds]
+  );
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((current) =>
+      current.includes(id) ? current.filter((item) => item !== id) : [...current, id]
+    );
+  };
+
+  return (
+    <div className="backtests-page">
+      <div className="landing-container">
+        <header className="backtests-header">
+          <div>
+            <span className="landing-badge">Portfolio runs</span>
+            <h1>Review backtests and compare strategies</h1>
+            <p>Monitor completed uploads, queue new simulations and overlay performance to find the portfolio mix that wins.</p>
+          </div>
+          <Link href="/upload" className="button button--primary">
+            New backtest
+          </Link>
+        </header>
+
+        <div className="backtests-toolbar">
+          <input
+            type="search"
+            placeholder="Search by name, strategy or symbol"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <div className="backtests-toolbar__actions">
+            <Link href="/dashboard" className="button button--outline">
+              Open dashboard
+            </Link>
+            <Link href="/features" className="button button--outline">
+              Learn the workflow
+            </Link>
+          </div>
+        </div>
+
+        <div className="backtests-grid">
+          {filtered.map((run) => (
+            <article key={run.id} className="backtest-card">
+              <header>
+                <div className="backtest-card__title">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(run.id)}
+                    onChange={() => toggleSelection(run.id)}
+                    aria-label={`Select ${run.name} for comparison`}
+                  />
+                  <div>
+                    <Link href={`/strategy/${run.id}`}>{run.name}</Link>
+                    <p>{run.strategy}</p>
+                  </div>
+                </div>
+                <span className={`tag ${run.status !== "complete" ? "tag--warning" : "tag--success"}`}>
+                  {run.status === "complete" ? "Complete" : run.status === "processing" ? "Processing" : "Queued"}
+                </span>
+              </header>
+              <div className="backtest-card__meta">
+                <span>{run.symbols.length} symbols</span>
+                <span>{run.timeframe}</span>
+                <span>{new Date(run.createdAt).toLocaleDateString()}</span>
+              </div>
+              <dl className="backtest-card__metrics">
+                <div>
+                  <dt>Net profit</dt>
+                  <dd>{formatCurrency(run.metrics.netProfit)}</dd>
+                </div>
+                <div>
+                  <dt>CAGR</dt>
+                  <dd>{formatPercent(run.metrics.cagr)}</dd>
+                </div>
+                <div>
+                  <dt>Max DD</dt>
+                  <dd>{formatPercent(run.metrics.maxDrawdown)}</dd>
+                </div>
+                <div>
+                  <dt>Sharpe</dt>
+                  <dd>{run.metrics.sharpe.toFixed(2)}</dd>
+                </div>
+              </dl>
+              <footer>
+                <div className="backtest-card__tags">
+                  {run.tags.map((tag) => (
+                    <span key={tag} className="tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <Link href={`/strategy/${run.id}`} className="button button--outline">
+                  View details
+                </Link>
+              </footer>
+            </article>
+          ))}
+        </div>
+
+        {selectedRuns.length >= 2 && (
+          <section className="comparison-panel" aria-labelledby="comparison-heading">
+            <div className="comparison-header">
+              <h2 id="comparison-heading">Side-by-side comparison</h2>
+              <p>
+                {selectedRuns.length} runs selected. Toggle the checkboxes above to add or remove strategies from this view.
+              </p>
+            </div>
+            <div className="comparison-table" role="table">
+              <div className="comparison-table__row comparison-table__row--head" role="row">
+                <div role="columnheader">Metric</div>
+                {selectedRuns.map((run) => (
+                  <div key={run.id} role="columnheader">
+                    {run.name}
+                  </div>
+                ))}
+              </div>
+              {renderMetricRow("Net profit", selectedRuns.map((run) => formatCurrency(run.metrics.netProfit)))}
+              {renderMetricRow("CAGR", selectedRuns.map((run) => formatPercent(run.metrics.cagr)))}
+              {renderMetricRow("Max drawdown", selectedRuns.map((run) => formatPercent(run.metrics.maxDrawdown)))}
+              {renderMetricRow("Sharpe", selectedRuns.map((run) => run.metrics.sharpe.toFixed(2)))}
+              {renderMetricRow("Win rate", selectedRuns.map((run) => formatPercent(run.metrics.winRate)))}
+              {renderMetricRow("Total trades", selectedRuns.map((run) => run.metrics.totalTrades.toString()))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderMetricRow(label: string, values: string[]) {
+  return (
+    <div className="comparison-table__row" role="row" key={label}>
+      <div role="cell" className="comparison-table__label">
+        {label}
+      </div>
+      {values.map((value, index) => (
+        <div role="cell" key={`${label}-${index}`}>
+          {value}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/app/features/page.tsx
+++ b/app/app/features/page.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import { flows, keyBenefits } from "../../lib/marketing-content";
+
+export default function FeaturesPage() {
+  return (
+    <div className="marketing-page">
+      <header className="marketing-hero">
+        <div className="landing-container">
+          <span className="landing-badge">Product tour</span>
+          <h1 className="marketing-hero__title">From CSV upload to portfolio clarity in minutes</h1>
+          <p className="marketing-hero__sub">
+            Explore the building blocks that power the multi-symbol backtesting workflow—designed around the exact jobs traders
+            told us they needed to finish.
+          </p>
+          <div className="marketing-hero__cta">
+            <Link href="/backtests?demo=1" className="button button--primary">
+              Launch demo workspace
+            </Link>
+            <Link href="/signup" className="button button--outline">
+              Create free account
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <section className="marketing-section" aria-labelledby="feature-benefits">
+        <div className="landing-container">
+          <h2 id="feature-benefits" className="landing-section-title">
+            Built around the jobs you hire us for
+          </h2>
+          <div className="landing-grid" role="list">
+            {keyBenefits.map((benefit) => (
+              <article key={benefit.title} className="landing-card" role="listitem">
+                <h3>{benefit.title}</h3>
+                <p>{benefit.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="marketing-section" aria-labelledby="flow-library">
+        <div className="landing-container">
+          <h2 id="flow-library" className="landing-section-title">
+            Three core flows cover the entire lifecycle
+          </h2>
+          <div className="flow-grid">
+            {flows.map((flow) => (
+              <article key={flow.id} className="flow-card">
+                <span className="tag">{flow.title}</span>
+                <p className="flow-card__description">{flow.description}</p>
+                <ol className="flow-card__steps">
+                  {flow.steps.map((step) => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ol>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="marketing-section" aria-labelledby="design-system">
+        <div className="landing-container">
+          <h2 id="design-system" className="landing-section-title">
+            A design system for clarity and speed
+          </h2>
+          <div className="design-grid">
+            <article className="card">
+              <div className="card__header">Accessible tokens</div>
+              <div className="card__body">
+                Color, spacing and typography tokens mirror the design spec so every component—buttons, alerts, tags—stays
+                consistent across marketing pages and in-app dashboards.
+              </div>
+            </article>
+            <article className="card">
+              <div className="card__header">Reusable components</div>
+              <div className="card__body">
+                Landing hero, KPI grids, flow cards and CTA banners are implemented as composable sections. Reuse them to extend
+                future pages without duplicating code.
+              </div>
+            </article>
+            <article className="card">
+              <div className="card__header">Responsive layouts</div>
+              <div className="card__body">
+                Grid utilities adapt from mobile to widescreen, ensuring traders can review results on desktops, tablets or phones
+                during market hours.
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section className="marketing-section marketing-section--cta" aria-labelledby="feature-cta">
+        <div className="landing-container">
+          <div className="landing-cta-box">
+            <div>
+              <span className="landing-badge">Ready when you are</span>
+              <h2 id="feature-cta">Put the workflow to work on your data</h2>
+              <p>
+                Bring your TradingView exports, run portfolio simulations instantly and compare strategies without leaving the
+                browser.
+              </p>
+            </div>
+            <div className="marketing-hero__cta">
+              <Link href="/upload" className="button button--primary">
+                Upload CSVs
+              </Link>
+              <Link href="/pricing" className="button button--outline">
+                Review pricing
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/app/feedback/page.tsx
+++ b/app/app/feedback/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+
+const feedbackAreas = [
+  "CSV upload",
+  "Portfolio metrics",
+  "Comparison workspace",
+  "Pricing & plans",
+  "Something else",
+];
+
+export default function FeedbackPage() {
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <div className="auth-page">
+      <div className="landing-container">
+        <div className="auth-card feedback-card">
+          <span className="landing-badge">We’d love your feedback</span>
+          <h1>Help us shape the roadmap</h1>
+          <p>Tell us what’s working, what’s missing and which features would save you the most time.</p>
+          {submitted ? (
+            <div className="alert alert--success" role="status">
+              Thank you for sharing your thoughts! We’ll be in touch if we have follow-up questions.
+            </div>
+          ) : (
+            <form
+              className="feedback-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                setSubmitted(true);
+              }}
+            >
+              <label>
+                <span>Your email</span>
+                <input type="email" name="email" required placeholder="you@example.com" />
+              </label>
+              <label>
+                <span>What part of the product are you commenting on?</span>
+                <select name="area" defaultValue={feedbackAreas[0]}>
+                  {feedbackAreas.map((area) => (
+                    <option key={area}>{area}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>How can we improve?</span>
+                <textarea name="message" rows={5} required placeholder="Share details, ideas or frustrations" />
+              </label>
+              <label>
+                <span>How likely are you to recommend us to a trading friend?</span>
+                <input type="range" name="nps" min="0" max="10" defaultValue="8" />
+              </label>
+              <button type="submit" className="button button--primary">
+                Send feedback
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,6 +1,8 @@
 import "../styles/globals.css";
 import { ReactNode } from "react";
 import Providers from "../components/providers";
+import { SiteHeader } from "../components/site-header";
+import { SiteFooter } from "../components/site-footer";
 
 export const metadata = {
   title: "Portfolio Backtester",
@@ -12,7 +14,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body>
         <Providers>
-          <div className="app-shell">{children}</div>
+          <div className="app-shell">
+            <SiteHeader />
+            <main className="site-main">{children}</main>
+            <SiteFooter />
+          </div>
         </Providers>
       </body>
     </html>

--- a/app/app/login/page.tsx
+++ b/app/app/login/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export default function LoginPage() {
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  return (
+    <div className="auth-page">
+      <div className="landing-container">
+        <div className="auth-card">
+          <span className="landing-badge">Welcome back</span>
+          <h1>Log in to continue your research</h1>
+          <p>Access saved backtests, compare strategies and manage your subscription.</p>
+          {success ? (
+            <div className="alert alert--success" role="status">
+              You are logged in. Redirecting to dashboard…
+            </div>
+          ) : (
+            <form
+              className="auth-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                const formData = new FormData(event.currentTarget);
+                if (!formData.get("email") || !formData.get("password")) {
+                  setError("Email and password are required.");
+                  return;
+                }
+                setError(null);
+                setSuccess(true);
+              }}
+            >
+              <label>
+                <span>Email</span>
+                <input type="email" name="email" required autoComplete="email" />
+              </label>
+              <label>
+                <span>Password</span>
+                <input type="password" name="password" required minLength={8} />
+              </label>
+              {error && (
+                <div className="alert alert--error" role="alert">
+                  {error}
+                </div>
+              )}
+              <button type="submit" className="button button--primary">
+                Log in
+              </button>
+            </form>
+          )}
+          <p className="auth-switch">
+            New here? <Link href="/signup">Create an account</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,88 +1,110 @@
 import Link from "next/link";
+import { faqItems, flows, keyBenefits } from "../lib/marketing-content";
 
-const struggles = [
+const painPoints = [
   {
-    title: "One symbol at a time",
+    title: "TradingView is single-symbol",
     description:
-      "Switching tickers and re-running backtests breaks flow and hides what happens when trades overlap.",
+      "Strategy Tester only handles one ticker at a time. Portfolio-level risk remains invisible until trades overlap in real accounts.",
   },
   {
-    title: "Spreadsheet blind spots",
+    title: "Spreadsheet gymnastics",
     description:
-      "Summed P&L misses correlation, capital rules, and true drawdown across a basket.",
+      "Exporting, merging and charting results manually costs hours every week and introduces errors that skew conclusions.",
   },
   {
-    title: "Slow iteration loop",
+    title: "Slow iteration loops",
     description:
-      "Dozens of manual runs per symbol stall parameter tuning and block evidence-based decisions.",
+      "Parameter tweaks require dozens of re-runs. Waiting for exports kills creative momentum when optimising a strategy.",
   },
   {
-    title: "Single-chart edge illusion",
+    title: "Confidence gap",
     description:
-      "What wins on one chart can sink a portfolio when signals cluster and risks compound.",
+      "Without aggregated equity curves and drawdown insight, traders hesitate to deploy capital or increase size.",
   },
 ];
 
-const steps = [
-  {
-    label: "Assemble your basket",
-    copy: "Pick symbols or strategy mix; define capital, position sizing, and concurrency.",
-  },
-  {
-    label: "Simulate portfolio",
-    copy: "Run multi-symbol backtests with real-world fills, slippage, and overlap handling.",
-  },
-  {
-    label: "Analyze risk",
-    copy: "Get combined equity, drawdown, correlation, exposure heatmaps, and factor tilts.",
-  },
-  {
-    label: "Optimize allocation",
-    copy: "Test weights, parameter sets, and rebalancing schedules to target risk-adjusted returns.",
-  },
-];
-
-const outcomes = [
-  {
-    title: "Evidence over anecdotes",
-    description:
-      "Decide with portfolio-level facts: true drawdown, capital usage, and correlation across holdings.",
-  },
-  {
-    title: "Speed to insight",
-    description:
-      "Turn hours of manual runs into minutes. Iterate faster on what actually improves risk-adjusted returns.",
-  },
-  {
-    title: "Smarter allocations",
-    description: "Find weights and rebalancing rules that reduce volatility without killing edge.",
-  },
-  {
-    title: "Confidence to deploy",
-    description: "Avoid nasty surprises from overlapping signals and clustered losses before you go live.",
-  },
+const highlightStats = [
+  { label: "Symbols per run", value: "50+" },
+  { label: "Aggregations per minute", value: "120" },
+  { label: "Avg time saved", value: "2h/day" },
+  { label: "Active beta users", value: "75" },
 ];
 
 export default function Home() {
   return (
     <main className="landing-root">
       <section className="landing-hero" aria-labelledby="hero-heading">
+        <div className="landing-container landing-hero__layout">
+          <div className="landing-hero__content">
+            <span className="landing-badge">Built for TradingView power-users</span>
+            <h1 id="hero-heading" className="landing-hero-title">
+              Backtest entire portfolios in one click
+            </h1>
+            <p className="landing-hero-sub">
+              Tired of running your strategy one symbol at a time? Upload TradingView CSVs and watch our cloud engine crunch 20+
+              symbols in seconds. Discover true portfolio performance without code, spreadsheets or guesswork.
+            </p>
+            <div className="landing-hero-cta" role="group" aria-label="Primary call to action">
+              <Link className="button button--primary" href="/backtests?demo=1">
+                Try on demo data
+              </Link>
+              <Link className="button button--outline" href="/upload">
+                Upload your first CSV
+              </Link>
+            </div>
+            <p className="landing-hero-note">No credit card required • Works with any TradingView strategy export</p>
+          </div>
+          <div className="landing-hero__panel" aria-label="Portfolio summary mock">
+            <div className="landing-kpi-grid">
+              <div className="landing-kpi">
+                <span className="label">Portfolio CAGR</span>
+                <span className="value">18.4%</span>
+              </div>
+              <div className="landing-kpi">
+                <span className="label">Sharpe</span>
+                <span className="value">1.21</span>
+              </div>
+              <div className="landing-kpi">
+                <span className="label">Max Drawdown</span>
+                <span className="value">-9.7%</span>
+              </div>
+              <div className="landing-kpi">
+                <span className="label">Win rate</span>
+                <span className="value">54%</span>
+              </div>
+            </div>
+            <div className="landing-chart-placeholder" role="img" aria-label="Portfolio equity curve placeholder">
+              Portfolio Equity Curve Placeholder
+            </div>
+            <p className="landing-panel-copy">
+              Combine trades across tickers, respect capital constraints and reveal the equity curve that matches how you really
+              trade.
+            </p>
+          </div>
+        </div>
+        <div className="landing-highlight-grid" role="list">
+          {highlightStats.map((stat) => (
+            <div key={stat.label} className="landing-highlight" role="listitem">
+              <span className="value">{stat.value}</span>
+              <span className="label">{stat.label}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="landing-section" id="benefits" aria-labelledby="benefits-heading">
         <div className="landing-container">
-          <span className="landing-badge">Portfolio Backtesting Workspace</span>
-          <h1 id="hero-heading" className="landing-hero-title">
-            Go from single-symbol guesses to true portfolio intelligence
-          </h1>
-          <p className="landing-hero-sub">
-            Run multi-symbol simulations, see combined equity curves, and optimize allocations in minutes. No more
-            tab-hopping or spreadsheet stitching.
-          </p>
-          <div className="landing-hero-cta" role="group" aria-label="Primary call to action">
-            <Link className="landing-btn" href="/upload">
-              Start free – 14 days
-            </Link>
-            <a className="landing-btn secondary" href="#how">
-              See how it works
-            </a>
+          <h2 id="benefits-heading" className="landing-section-title">
+            Why traders are switching
+          </h2>
+          <div className="landing-grid" role="list">
+            {keyBenefits.map((benefit) => (
+              <article key={benefit.title} className="landing-card" role="listitem">
+                <h3>{benefit.title}</h3>
+                <p>{benefit.description}</p>
+              </article>
+            ))}
           </div>
         </div>
       </section>
@@ -90,96 +112,99 @@ export default function Home() {
       <section className="landing-section" id="pain" aria-labelledby="pain-heading">
         <div className="landing-container">
           <h2 id="pain-heading" className="landing-section-title">
-            Current Struggles
+            The current workaround is broken
           </h2>
           <div className="landing-grid" role="list">
-            {struggles.map((struggle) => (
-              <article key={struggle.title} className="landing-card" role="listitem">
-                <h3>{struggle.title}</h3>
-                <p>{struggle.description}</p>
+            {painPoints.map((pain) => (
+              <article key={pain.title} className="landing-benefit" role="listitem">
+                <h4>{pain.title}</h4>
+                <p>{pain.description}</p>
               </article>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="landing-section" id="how" aria-labelledby="how-heading">
+      <section className="landing-section" id="flows" aria-labelledby="flow-heading">
         <div className="landing-container">
-          <h2 id="how-heading" className="landing-section-title">
-            How it works
+          <h2 id="flow-heading" className="landing-section-title">
+            Designed for seamless multi-symbol workflows
+          </h2>
+          <div className="flow-grid">
+            {flows.map((flow) => (
+              <article key={flow.id} className="flow-card">
+                <span className="tag">{flow.title}</span>
+                <p className="flow-card__description">{flow.description}</p>
+                <ol className="flow-card__steps">
+                  {flow.steps.map((step) => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ol>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="landing-section" id="demo" aria-labelledby="demo-heading">
+        <div className="landing-container">
+          <h2 id="demo-heading" className="landing-section-title">
+            See the full portfolio picture instantly
           </h2>
           <div className="landing-feature">
             <div className="landing-panel" aria-label="Portfolio metrics mock">
               <div className="landing-kpi-grid">
                 <div className="landing-kpi">
-                  <span className="label">Portfolio CAGR</span>
-                  <span className="value">18.4%</span>
+                  <span className="label">Net Profit</span>
+                  <span className="value">$34,250</span>
                 </div>
                 <div className="landing-kpi">
-                  <span className="label">Max Drawdown</span>
-                  <span className="value">-9.7%</span>
+                  <span className="label">Exposure at risk</span>
+                  <span className="value">32%</span>
                 </div>
                 <div className="landing-kpi">
-                  <span className="label">Sharpe</span>
-                  <span className="value">1.21</span>
+                  <span className="label">Best symbol</span>
+                  <span className="value">NVDA</span>
                 </div>
                 <div className="landing-kpi">
-                  <span className="label">Hit Rate</span>
-                  <span className="value">54%</span>
+                  <span className="label">Losing cluster</span>
+                  <span className="value">Apr ‘23</span>
                 </div>
               </div>
-              <div className="landing-chart-placeholder" role="img" aria-label="Portfolio equity curve placeholder">
-                Portfolio Equity Curve Placeholder
+              <div className="landing-chart-placeholder" role="img" aria-label="Comparison chart placeholder">
+                Strategy Comparison Placeholder
               </div>
               <p className="landing-panel-copy">
-                Upload results or connect data, select symbols and rules, then simulate portfolio-level performance with
-                capital allocation and concurrency.
+                Contrast strategies, toggle symbols on/off and export summary packs ready for investors or prop firm reviews.
               </p>
             </div>
 
             <div className="landing-panel">
-              <ol className="landing-stepper">
-                {steps.map((step, index) => (
-                  <li key={step.label} className="landing-step">
-                    <span className="index" aria-hidden="true">
-                      {index + 1}
-                    </span>
-                    <div>
-                      <strong>{step.label}</strong>
-                      <p>{step.copy}</p>
-                    </div>
-                  </li>
-                ))}
-              </ol>
-              <form
-                id="signup"
-                className="landing-inline-form"
-                aria-label="Email capture"
-                onSubmit={(event) => event.preventDefault()}
-              >
-                <label className="sr-only" htmlFor="beta-email">
-                  Email address
-                </label>
-                <input id="beta-email" type="email" placeholder="Enter your email to join the beta" required />
-                <button type="submit" className="landing-btn">
-                  Get early access
-                </button>
-              </form>
+              <h3 className="landing-panel-title">Upload → Aggregate → Decide</h3>
+              <ul className="landing-feature-list">
+                <li>Batch import TradingView CSVs with automated validation and tagging.</li>
+                <li>Aggregate trades respecting capital, concurrency and per-symbol slippage assumptions.</li>
+                <li>Visualise portfolio equity, drawdown, exposure heatmaps and trade distributions.</li>
+                <li>Compare strategies side-by-side to find the best combination for your goals.</li>
+              </ul>
+              <Link className="button button--primary" href="/backtests?demo=1">
+                Launch demo workspace
+              </Link>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="landing-section" aria-labelledby="outcomes-heading">
+      <section className="landing-section" aria-labelledby="faq-heading">
         <div className="landing-container">
-          <h2 id="outcomes-heading" className="landing-section-title">
-            Outcomes you can expect
+          <h2 id="faq-heading" className="landing-section-title">
+            Frequently asked questions
           </h2>
-          <div className="landing-grid" role="list">
-            {outcomes.map((outcome) => (
-              <article key={outcome.title} className="landing-benefit" role="listitem">
-                <h4>{outcome.title}</h4>
-                <p>{outcome.description}</p>
+          <div className="faq-grid">
+            {faqItems.map((faq) => (
+              <article key={faq.question} className="faq-card">
+                <h3>{faq.question}</h3>
+                <p>{faq.answer}</p>
               </article>
             ))}
           </div>
@@ -194,11 +219,7 @@ export default function Home() {
               <h3 id="cta-heading">Join the early access cohort</h3>
               <p>Spots this month are capped to ensure fast onboarding and support.</p>
             </div>
-            <form
-              className="landing-inline-form"
-              aria-label="Reserve spot"
-              onSubmit={(event) => event.preventDefault()}
-            >
+            <form className="landing-inline-form" aria-label="Reserve spot" onSubmit={(event) => event.preventDefault()}>
               <label className="sr-only" htmlFor="cta-email">
                 Email address
               </label>
@@ -207,30 +228,6 @@ export default function Home() {
                 Reserve my spot
               </button>
             </form>
-          </div>
-        </div>
-      </section>
-
-      <section className="landing-section" aria-labelledby="founder-heading">
-        <div className="landing-container">
-          <h2 id="founder-heading" className="landing-section-title">
-            From the founder
-          </h2>
-          <div className="landing-founder-card">
-            <div className="avatar" aria-hidden="true" />
-            <div>
-              <p>
-                “After years of single-symbol testing and spreadsheet hacks, we built the tool we wished existed: fast,
-                honest, portfolio-level backtesting that surfaces risk before capital is on the line.”
-              </p>
-              <p className="landing-founder-signoff">
-                <strong>Your Name</strong> — Founder
-              </p>
-            </div>
-          </div>
-          <div className="landing-panel landing-testimonial-placeholder" aria-label="Testimonials placeholder">
-            Testimonials coming soon. Add 2–3 concise quotes focused on time saved, clarity of risk, and confidence to
-            deploy.
           </div>
         </div>
       </section>

--- a/app/app/pricing/page.tsx
+++ b/app/app/pricing/page.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { faqItems, pricingPlans } from "../../lib/marketing-content";
+
+export default function PricingPage() {
+  const supportFaq = faqItems.slice(3, 6);
+
+  return (
+    <div className="marketing-page">
+      <header className="marketing-hero">
+        <div className="landing-container">
+          <span className="landing-badge">Simple pricing</span>
+          <h1 className="marketing-hero__title">Flexible plans for every stage of your trading journey</h1>
+          <p className="marketing-hero__sub">
+            Start free, upgrade when you need higher symbol limits, automation or advanced analytics. No contracts, cancel any
+            time.
+          </p>
+          <div className="marketing-hero__cta">
+            <Link href="/signup" className="button button--primary">
+              Start free
+            </Link>
+            <Link href="/features" className="button button--outline">
+              Explore features
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <section className="marketing-section" aria-labelledby="plans-heading">
+        <div className="landing-container">
+          <h2 id="plans-heading" className="landing-section-title">
+            Choose a plan that scales with your research
+          </h2>
+          <div className="pricing-grid">
+            {pricingPlans.map((plan) => (
+              <article key={plan.name} className="plan-card">
+                <div className="plan-card__badge">{plan.badge}</div>
+                <h3>{plan.name}</h3>
+                <p className="plan-card__price">
+                  {plan.price}
+                  <span>{plan.cadence}</span>
+                </p>
+                <p className="plan-card__description">{plan.description}</p>
+                <ul>
+                  {plan.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+                <Link href="/signup" className="button button--primary plan-card__cta">
+                  {plan.name === "Free" ? "Create free account" : `Upgrade to ${plan.name}`}
+                </Link>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="marketing-section" aria-labelledby="billing-faq">
+        <div className="landing-container">
+          <h2 id="billing-faq" className="landing-section-title">
+            Billing questions, answered
+          </h2>
+          <div className="faq-grid">
+            {supportFaq.map((faq) => (
+              <article key={faq.question} className="faq-card">
+                <h3>{faq.question}</h3>
+                <p>{faq.answer}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="marketing-section marketing-section--cta" aria-labelledby="pricing-cta">
+        <div className="landing-container">
+          <div className="landing-cta-box">
+            <div>
+              <span className="landing-badge">Need a custom plan?</span>
+              <h2 id="pricing-cta">Talk to us about enterprise or prop-firm deployments</h2>
+              <p>White-label options, API quotas and dedicated support available for desks that need custom agreements.</p>
+            </div>
+            <Link href="mailto:hello@portfoliobacktester.com" className="button button--outline">
+              Contact sales
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/app/roadmap/page.tsx
+++ b/app/app/roadmap/page.tsx
@@ -1,0 +1,45 @@
+import { roadmapMilestones } from "../../lib/marketing-content";
+
+const statusToLabel: Record<string, string> = {
+  complete: "Complete",
+  "in-progress": "In progress",
+  "up-next": "Up next",
+  planned: "Planned",
+};
+
+export default function RoadmapPage() {
+  return (
+    <div className="marketing-page">
+      <header className="marketing-hero">
+        <div className="landing-container">
+          <span className="landing-badge">Roadmap</span>
+          <h1 className="marketing-hero__title">Twelve-week MVP plan to deliver multi-symbol backtesting</h1>
+          <p className="marketing-hero__sub">
+            Track our weekly milestones as we move from discovery to beta launch. Feedback from power-users continually shapes
+            what ships next.
+          </p>
+        </div>
+      </header>
+
+      <section className="marketing-section" aria-labelledby="timeline-heading">
+        <div className="landing-container">
+          <h2 id="timeline-heading" className="landing-section-title">
+            Execution timeline
+          </h2>
+          <ol className="roadmap-list">
+            {roadmapMilestones.map((item) => (
+              <li key={item.title} className={`roadmap-item roadmap-item--${item.status}`}>
+                <div className="roadmap-item__header">
+                  <span className="roadmap-item__badge">{item.quarter}</span>
+                  <span className="roadmap-item__status">{statusToLabel[item.status]}</span>
+                </div>
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/app/signup/page.tsx
+++ b/app/app/signup/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export default function SignupPage() {
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <div className="auth-page">
+      <div className="landing-container">
+        <div className="auth-card">
+          <span className="landing-badge">Create account</span>
+          <h1>Join the portfolio backtesting beta</h1>
+          <p>Import TradingView CSVs, run multi-symbol backtests and compare strategies without leaving your browser.</p>
+          {submitted ? (
+            <div className="alert alert--success" role="status">
+              Thanks! Check your inbox for a confirmation email with next steps.
+            </div>
+          ) : (
+            <form
+              className="auth-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                setSubmitted(true);
+              }}
+            >
+              <label>
+                <span>Full name</span>
+                <input type="text" name="name" required autoComplete="name" />
+              </label>
+              <label>
+                <span>Email</span>
+                <input type="email" name="email" required autoComplete="email" />
+              </label>
+              <label>
+                <span>Password</span>
+                <input type="password" name="password" required minLength={8} />
+              </label>
+              <label>
+                <span>Primary trading focus</span>
+                <select name="focus" defaultValue="stocks">
+                  <option value="stocks">Equities</option>
+                  <option value="forex">Forex</option>
+                  <option value="crypto">Crypto</option>
+                  <option value="futures">Futures</option>
+                </select>
+              </label>
+              <button type="submit" className="button button--primary">
+                Create my account
+              </button>
+            </form>
+          )}
+          <p className="auth-switch">
+            Already have an account? <Link href="/login">Log in</Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/strategy/[id]/page.tsx
+++ b/app/app/strategy/[id]/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { KPITile } from "../../../components/kpi-tile";
+import { FileTable } from "../../../components/file-table";
+import { formatCurrency, formatPercent } from "../../../lib/format";
+import { mockBacktests } from "../../../lib/mock-data";
+import { StrategyEquity } from "./strategy-equity";
+
+export default function StrategyDetailPage({ params }: { params: { id: string } }) {
+  const run = mockBacktests.find((item) => item.id === params.id);
+  if (!run) {
+    notFound();
+  }
+
+  return (
+    <div className="strategy-page">
+      <div className="landing-container">
+        <header className="strategy-header">
+          <div>
+            <span className="landing-badge">Portfolio result</span>
+            <h1>{run.name}</h1>
+            <p>{run.strategy} • {run.symbols.length} symbols • {run.timeframe} timeframe</p>
+            <div className="backtest-card__tags">
+              {run.tags.map((tag) => (
+                <span key={tag} className="tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+          <Link href="/backtests" className="button button--outline">
+            ← Back to backtests
+          </Link>
+        </header>
+
+        {run.equityCurve.length > 0 ? (
+          <StrategyEquity equityCurve={run.equityCurve} drawdown={run.drawdown} />
+        ) : (
+          <div className="tv-card p-6 text-sm text-slate-300">This backtest is still processing. Check again shortly.</div>
+        )}
+
+        <section className="strategy-metrics" aria-labelledby="metrics-heading">
+          <h2 id="metrics-heading">Key metrics</h2>
+          <div className="strategy-metrics__grid">
+            <KPITile label="Net profit" value={run.metrics.netProfit} format="currency" />
+            <KPITile label="Portfolio CAGR" value={run.metrics.cagr} format="percent" />
+            <KPITile label="Max drawdown" value={run.metrics.maxDrawdown} format="percent" />
+            <KPITile label="Sharpe" value={run.metrics.sharpe} format="raw" />
+            <KPITile label="Win rate" value={run.metrics.winRate} format="percent" />
+            <KPITile label="Total trades" value={run.metrics.totalTrades} format="raw" />
+          </div>
+        </section>
+
+        <section className="strategy-notes" aria-labelledby="notes-heading">
+          <h2 id="notes-heading">Run notes</h2>
+          <p>{run.notes ?? "No notes captured for this run yet."}</p>
+        </section>
+
+        <section className="strategy-trades" aria-labelledby="trades-heading">
+          <div className="strategy-trades__heading">
+            <div>
+              <h2 id="trades-heading">Trades preview</h2>
+              <p>First {run.tradesTable.length || "0"} trades from the merged CSVs.</p>
+            </div>
+            <div className="strategy-trades__totals">
+              <span>Total P&L: {formatCurrency(run.metrics.netProfit)}</span>
+              <span>Win rate: {formatPercent(run.metrics.winRate)}</span>
+            </div>
+          </div>
+          <FileTable trades={run.tradesTable} />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/app/strategy/[id]/strategy-equity.tsx
+++ b/app/app/strategy/[id]/strategy-equity.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { EquityChart } from "../../../components/equity-chart";
+
+type Props = {
+  equityCurve: Array<{ timestamp: string; value: number }>;
+  drawdown: Array<{ timestamp: string; value: number }>;
+};
+
+export function StrategyEquity({ equityCurve, drawdown }: Props) {
+  if (!equityCurve.length) {
+    return null;
+  }
+
+  return <EquityChart equityCurve={equityCurve} drawdown={drawdown} />;
+}

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+
+export function SiteFooter() {
+  return (
+    <footer className="site-footer">
+      <div className="site-footer__inner">
+        <div>
+          <h2 className="site-footer__title">Portfolio Backtester</h2>
+          <p className="site-footer__copy">
+            The missing multi-symbol backtesting layer for TradingView power-users. Upload CSVs, aggregate instantly and act with
+            confidence.
+          </p>
+        </div>
+        <div className="site-footer__links">
+          <div>
+            <h3>Product</h3>
+            <ul>
+              <li>
+                <Link href="/features">Features</Link>
+              </li>
+              <li>
+                <Link href="/pricing">Pricing</Link>
+              </li>
+              <li>
+                <Link href="/backtests">Backtests</Link>
+              </li>
+              <li>
+                <Link href="/roadmap">Roadmap</Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3>Company</h3>
+            <ul>
+              <li>
+                <Link href="/feedback">Feedback</Link>
+              </li>
+              <li>
+                <Link href="/signup">Create account</Link>
+              </li>
+              <li>
+                <Link href="/login">Log in</Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div className="site-footer__meta">
+        <p>© {new Date().getFullYear()} Portfolio Backtester. All rights reserved.</p>
+        <div className="site-footer__meta-links">
+          <Link href="#">Terms</Link>
+          <Link href="#">Privacy</Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/app/components/site-header.tsx
+++ b/app/components/site-header.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+const navLinks = [
+  { href: "/features", label: "Features" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/backtests", label: "Backtests" },
+  { href: "/roadmap", label: "Roadmap" },
+  { href: "/feedback", label: "Feedback" },
+];
+
+export function SiteHeader() {
+  return (
+    <header className="site-header">
+      <div className="site-header__inner">
+        <Link href="/" className="site-header__logo" aria-label="Portfolio backtester home">
+          <span className="site-header__mark" aria-hidden="true" />
+          <span className="site-header__title">Portfolio Backtester</span>
+        </Link>
+        <nav aria-label="Primary">
+          <ul className="site-nav">
+            {navLinks.map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className="site-nav__link">
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <div className="site-header__actions">
+          <Link href="/login" className="button button--outline">
+            Log in
+          </Link>
+          <Link href="/signup" className="button button--primary">
+            Join beta
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/app/lib/marketing-content.ts
+++ b/app/lib/marketing-content.ts
@@ -1,0 +1,169 @@
+export const keyBenefits = [
+  {
+    title: "Save Hours Every Week",
+    description:
+      "Automate the tedious export-and-merge workflow. Traders report reclaiming two hours a day compared with spreadsheets.",
+  },
+  {
+    title: "Boost Strategy Confidence",
+    description:
+      "Understand how each symbol contributes to portfolio risk and return so you can deploy capital with conviction.",
+  },
+  {
+    title: "No Code, No Hassle",
+    description:
+      "Import TradingView CSVs and receive portfolio analytics instantly. If you know TradingView, you already know how to use this.",
+  },
+  {
+    title: "Insightful Metrics at a Glance",
+    description:
+      "Review portfolio CAGR, max drawdown, Sharpe, correlation and more without leaving the browser.",
+  },
+];
+
+export const faqItems = [
+  {
+    question: "Will this work without Pine Script?",
+    answer:
+      "Yes. Upload the trade CSVs generated from TradingView or any other platform. We analyse raw trade data—no Pine execution required.",
+  },
+  {
+    question: "Do I need to be a programmer?",
+    answer:
+      "No coding skills are needed. The workflow mirrors TradingView's Strategy Tester with a guided upload wizard and interactive dashboards.",
+  },
+  {
+    question: "Is my strategy data safe?",
+    answer:
+      "All uploads are encrypted in transit and at rest. You stay in control of your data, and you can opt for client-side only processing if preferred.",
+  },
+  {
+    question: "How is this different from other backtest platforms?",
+    answer:
+      "We focus on TradingView power-users. Instead of rewriting strategies in another language, simply reuse your existing exports and get portfolio-ready analytics.",
+  },
+  {
+    question: "Is there a free version?",
+    answer:
+      "Yes. The Free tier supports up to three symbols per backtest. Upgrade to unlock unlimited symbols, longer history and advanced comparison reports.",
+  },
+  {
+    question: "How much data can it handle?",
+    answer:
+      "Our compute pipeline comfortably processes hundreds of thousands of trades. Even ten years of data across 50 symbols completes in seconds.",
+  },
+];
+
+export const flows = [
+  {
+    id: "flow-1",
+    title: "Flow 1: Onboarding to First Portfolio Result",
+    description:
+      "Guide new users from signup to their first combined equity curve with an empty state, CSV upload modal and automated aggregation.",
+    steps: [
+      "Create an account and land on the dashboard with an empty state call-to-action.",
+      "Upload multiple TradingView CSVs via the guided modal with validation feedback.",
+      "Watch the processing status update in real-time as the backend merges trades.",
+      "Review the aggregated equity curve, KPIs and trade list once the run completes.",
+    ],
+  },
+  {
+    id: "flow-2",
+    title: "Flow 2: Compare Strategies Across Symbols",
+    description:
+      "Enable power-users to evaluate multiple runs at once, selecting backtests and viewing overlayed metrics and equity curves.",
+    steps: [
+      "Pick completed backtests from the list view using multi-select controls.",
+      "Open the comparison workspace to see equity curves stacked together.",
+      "Sort metrics by Sharpe, drawdown or hit-rate to spot the most resilient mix.",
+      "Decide which strategy to iterate on next or duplicate configurations for re-runs.",
+    ],
+  },
+  {
+    id: "flow-3",
+    title: "Flow 3: Subscribe and Unlock Pro Features",
+    description:
+      "Upgrade paths surface when users hit Free tier limits, leading into a secure Stripe checkout and instant plan activation.",
+    steps: [
+      "Preview plan benefits from the pricing page or in-app upgrade prompts.",
+      "Launch Stripe Checkout with prefilled plan metadata for a smooth payment experience.",
+      "Return to the dashboard with confirmation messaging and increased symbol limits.",
+      "Access premium capabilities such as unlimited uploads and advanced analytics.",
+    ],
+  },
+];
+
+export const pricingPlans = [
+  {
+    name: "Free",
+    price: "$0",
+    cadence: "forever",
+    badge: "Start here",
+    description: "Test small portfolios with core analytics and demo data.",
+    features: [
+      "Up to 3 symbols per backtest",
+      "Two concurrent uploads",
+      "Portfolio KPIs and equity chart",
+      "Email support within 48 hours",
+    ],
+  },
+  {
+    name: "Standard",
+    price: "$19",
+    cadence: "per month",
+    badge: "Most popular",
+    description: "Perfect for serious retail quants balancing speed and depth.",
+    features: [
+      "Up to 15 symbols per backtest",
+      "Parameter snapshots & saved presets",
+      "Comparison workspace",
+      "Priority support with Slack community",
+    ],
+  },
+  {
+    name: "Pro",
+    price: "$29",
+    cadence: "per month",
+    badge: "For power users",
+    description: "Unlimited scale, automation hooks and white-glove onboarding.",
+    features: [
+      "Unlimited symbols and history",
+      "API access & webhook automations",
+      "Advanced risk analytics (exposure, factor tilt)",
+      "Same-day expert support",
+    ],
+  },
+];
+
+export const roadmapMilestones = [
+  {
+    quarter: "Week 1",
+    title: "Requirements & Architecture",
+    description: "Finalize technical design, set up repo, CI and data schemas for TradingView CSV ingestion.",
+    status: "complete",
+  },
+  {
+    quarter: "Week 4",
+    title: "Backend Aggregation Engine",
+    description: "Deliver the portfolio merge service that computes P&L, drawdown and metrics for uploaded CSV batches.",
+    status: "in-progress",
+  },
+  {
+    quarter: "Week 6",
+    title: "Alpha Testing",
+    description: "Invite early users to upload data, capture edge cases and harden parsing logic.",
+    status: "up-next",
+  },
+  {
+    quarter: "Week 9",
+    title: "Marketing & Pricing Rollout",
+    description: "Publish features and pricing pages, integrate analytics and prep for beta launch.",
+    status: "planned",
+  },
+  {
+    quarter: "Week 12",
+    title: "Public Beta",
+    description: "Scale beta invites, collect testimonials and monitor performance for wider release.",
+    status: "planned",
+  },
+];

--- a/app/lib/mock-data.ts
+++ b/app/lib/mock-data.ts
@@ -1,0 +1,149 @@
+export type BacktestRun = {
+  id: string;
+  name: string;
+  strategy: string;
+  symbols: string[];
+  timeframe: string;
+  createdAt: string;
+  status: "complete" | "processing" | "queued";
+  metrics: {
+    netProfit: number;
+    cagr: number;
+    maxDrawdown: number;
+    sharpe: number;
+    winRate: number;
+    totalTrades: number;
+  };
+  tags: string[];
+  equityCurve: Array<{ timestamp: string; value: number }>;
+  drawdown: Array<{ timestamp: string; value: number }>;
+  tradesTable: Array<Record<string, unknown>>;
+  notes?: string;
+};
+
+const baselineEquity = [
+  { timestamp: "2023-01-01", value: 100000 },
+  { timestamp: "2023-03-01", value: 108000 },
+  { timestamp: "2023-06-01", value: 118500 },
+  { timestamp: "2023-09-01", value: 126400 },
+  { timestamp: "2023-12-01", value: 134200 },
+];
+
+const baselineDrawdown = [
+  { timestamp: "2023-01-01", value: 0 },
+  { timestamp: "2023-03-01", value: -0.02 },
+  { timestamp: "2023-06-01", value: -0.04 },
+  { timestamp: "2023-09-01", value: -0.01 },
+  { timestamp: "2023-12-01", value: -0.03 },
+];
+
+const baseTrades: Array<Record<string, unknown>> = [
+  {
+    tradeId: "TV-001",
+    symbol: "AAPL",
+    direction: "Long",
+    opened_at: "2023-01-03T14:30:00Z",
+    closed_at: "2023-01-10T15:45:00Z",
+    pnl: 1450.24,
+    bars_held: 8,
+  },
+  {
+    tradeId: "TV-002",
+    symbol: "MSFT",
+    direction: "Short",
+    opened_at: "2023-02-14T09:30:00Z",
+    closed_at: "2023-02-20T16:00:00Z",
+    pnl: -320.5,
+    bars_held: 5,
+  },
+  {
+    tradeId: "TV-003",
+    symbol: "NVDA",
+    direction: "Long",
+    opened_at: "2023-04-01T09:30:00Z",
+    closed_at: "2023-04-12T14:00:00Z",
+    pnl: 2350.9,
+    bars_held: 9,
+  },
+];
+
+export const mockBacktests: BacktestRun[] = [
+  {
+    id: "alpha-tech",
+    name: "Alpha Momentum Tech",
+    strategy: "TV Momentum Stack",
+    symbols: ["AAPL", "MSFT", "NVDA", "AMD", "GOOGL"],
+    timeframe: "Daily",
+    createdAt: "2024-04-10T08:15:00Z",
+    status: "complete",
+    metrics: {
+      netProfit: 34250,
+      cagr: 18.4,
+      maxDrawdown: -9.7,
+      sharpe: 1.21,
+      winRate: 54,
+      totalTrades: 126,
+    },
+    tags: ["Stocks", "Momentum", "Equal weight"],
+    equityCurve: baselineEquity,
+    drawdown: baselineDrawdown,
+    tradesTable: baseTrades,
+    notes: "Outperforms benchmark when volatility is moderate; monitor Nvidia weighting.",
+  },
+  {
+    id: "fx-carry",
+    name: "SteadyFX Carry",
+    strategy: "FX Carry Overlay",
+    symbols: ["EURUSD", "USDJPY", "AUDUSD", "GBPUSD"],
+    timeframe: "4H",
+    createdAt: "2024-03-21T12:05:00Z",
+    status: "complete",
+    metrics: {
+      netProfit: 18780,
+      cagr: 12.9,
+      maxDrawdown: -6.2,
+      sharpe: 1.08,
+      winRate: 62,
+      totalTrades: 214,
+    },
+    tags: ["Forex", "Carry", "Low volatility"],
+    equityCurve: [
+      { timestamp: "2023-01-01", value: 100000 },
+      { timestamp: "2023-03-01", value: 103200 },
+      { timestamp: "2023-06-01", value: 109000 },
+      { timestamp: "2023-09-01", value: 112400 },
+      { timestamp: "2023-12-01", value: 118780 },
+    ],
+    drawdown: [
+      { timestamp: "2023-01-01", value: 0 },
+      { timestamp: "2023-03-01", value: -0.015 },
+      { timestamp: "2023-06-01", value: -0.03 },
+      { timestamp: "2023-09-01", value: -0.012 },
+      { timestamp: "2023-12-01", value: -0.02 },
+    ],
+    tradesTable: baseTrades.map((trade, index) => ({ ...trade, tradeId: `FX-${index + 1}` })),
+    notes: "Stable carry basket; add risk overlay before going live with higher leverage.",
+  },
+  {
+    id: "multi-strat",
+    name: "Adaptive Multi-Strat",
+    strategy: "Composite Portfolio",
+    symbols: ["AAPL", "TSLA", "BTCUSD", "ETHUSD", "GLD"],
+    timeframe: "Daily",
+    createdAt: "2024-02-18T17:45:00Z",
+    status: "processing",
+    metrics: {
+      netProfit: 0,
+      cagr: 0,
+      maxDrawdown: 0,
+      sharpe: 0,
+      winRate: 0,
+      totalTrades: 0,
+    },
+    tags: ["Hybrid", "Crypto", "Equities"],
+    equityCurve: [],
+    drawdown: [],
+    tradesTable: [],
+    notes: "Combines long momentum equities with crypto mean reversion—currently running.",
+  },
+];

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -17,6 +17,40 @@
   --tv-radius: 12px;
   --tv-shadow: 0 16px 40px rgba(9, 12, 20, 0.55);
   --tv-max-width: 1120px;
+
+  /* Marketing design tokens */
+  --color-primary: #3b82f6;
+  --color-primary-dark: #1e40af;
+  --color-neutral-900: #111111;
+  --color-neutral-100: #f3f4f6;
+  --color-success: #16a34a;
+  --color-warning: #f59e0b;
+  --color-danger: #dc2626;
+
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 16px;
+  --spacing-4: 32px;
+  --spacing-5: 64px;
+
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.2rem;
+  --font-size-xl: 1.44rem;
+  --font-size-2xl: 1.728rem;
+  --font-size-3xl: 2.074rem;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 20px rgba(0, 0, 0, 0.15);
+
+  --transition-default: 0.3s ease-in-out;
+  --transition-fast: 0.2s ease-in-out;
 }
 
 html {
@@ -42,11 +76,326 @@ a:hover {
   color: var(--tv-accent);
 }
 
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-1);
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--color-primary), #60a5fa);
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(59, 130, 246, 0.35);
+}
+
+.button--primary:hover {
+  background: linear-gradient(135deg, var(--color-primary-dark), #3b82f6);
+  box-shadow: 0 12px 26px rgba(59, 130, 246, 0.45);
+}
+
+.button--outline {
+  background: transparent;
+  color: var(--color-primary);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.button--outline:hover {
+  background: rgba(59, 130, 246, 0.08);
+  color: #fff;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--tv-heading);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tag--success {
+  background: rgba(22, 163, 74, 0.2);
+  color: #bbf7d0;
+}
+
+.tag--warning {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fcd34d;
+}
+
+.tag--danger {
+  background: rgba(220, 38, 38, 0.2);
+  color: #fecaca;
+}
+
+.alert {
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-base);
+}
+
+.alert--success {
+  background: rgba(22, 163, 74, 0.18);
+  color: #bbf7d0;
+}
+
+.alert--warning {
+  background: rgba(245, 158, 11, 0.16);
+  color: #fcd34d;
+}
+
+.alert--error {
+  background: rgba(220, 38, 38, 0.16);
+  color: #fecaca;
+}
+
+.card {
+  border-radius: var(--radius-md);
+  background: var(--tv-panel);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--tv-shadow);
+  padding: var(--spacing-4);
+}
+
+.card__header {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  margin-bottom: var(--spacing-2);
+}
+
+.card__body {
+  font-size: var(--font-size-base);
+  color: var(--tv-muted);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+}
+
+.modal__dialog {
+  width: min(520px, 90vw);
+  background: var(--tv-panel);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-4);
+  box-shadow: var(--tv-shadow);
+}
+
+.modal__header {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  margin-bottom: var(--spacing-3);
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+}
+
 .app-shell {
   min-height: 100vh;
   background: radial-gradient(circle at top left, rgba(41, 98, 255, 0.12), transparent 55%),
     radial-gradient(circle at bottom right, rgba(19, 23, 34, 0.6), rgba(19, 23, 34, 0.9));
   color: inherit;
+}
+
+.site-main {
+  min-height: calc(100vh - 220px);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(12px);
+  background: rgba(12, 16, 27, 0.88);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.site-header__inner {
+  width: min(100%, var(--tv-max-width));
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.site-header__logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+  color: var(--tv-heading);
+}
+
+.site-header__mark {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #2962ff, #00b9f1);
+  box-shadow: 0 8px 20px rgba(0, 185, 241, 0.35);
+}
+
+.site-header__title {
+  display: none;
+}
+
+@media (min-width: 640px) {
+  .site-header__title {
+    display: inline-flex;
+  }
+}
+
+.site-nav {
+  list-style: none;
+  display: none;
+  gap: 18px;
+  margin: 0 auto 0 0;
+  padding: 0;
+}
+
+@media (min-width: 900px) {
+  .site-nav {
+    display: inline-flex;
+  }
+}
+
+.site-nav__link {
+  color: var(--tv-muted);
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 999px;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus {
+  color: var(--tv-heading);
+  background: rgba(41, 98, 255, 0.12);
+}
+
+.site-header__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.site-footer {
+  margin-top: clamp(64px, 12vw, 120px);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 12, 19, 0.9);
+  padding: clamp(48px, 8vw, 72px) 0 32px;
+}
+
+.site-footer__inner {
+  width: min(100%, var(--tv-max-width));
+  margin: 0 auto;
+  padding: 0 24px 32px;
+  display: grid;
+  gap: 32px;
+}
+
+@media (min-width: 900px) {
+  .site-footer__inner {
+    grid-template-columns: 1.2fr 1fr;
+    align-items: start;
+  }
+}
+
+.site-footer__title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+  margin-bottom: 10px;
+}
+
+.site-footer__copy {
+  color: var(--tv-muted);
+  line-height: 1.6;
+  max-width: 420px;
+}
+
+.site-footer__links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.site-footer__links h3 {
+  color: var(--tv-heading);
+  font-size: 1rem;
+  margin-bottom: 12px;
+}
+
+.site-footer__links ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.site-footer__links a {
+  color: var(--tv-muted);
+  font-size: 0.95rem;
+}
+
+.site-footer__links a:hover {
+  color: var(--tv-heading);
+}
+
+.site-footer__meta {
+  width: min(100%, var(--tv-max-width));
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--tv-muted);
+}
+
+@media (min-width: 700px) {
+  .site-footer__meta {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.site-footer__meta-links {
+  display: flex;
+  gap: 16px;
+}
+
+.site-footer__meta-links a {
+  color: var(--tv-muted);
+}
+
+.site-footer__meta-links a:hover {
+  color: var(--tv-heading);
 }
 
 .tv-card {
@@ -79,8 +428,596 @@ a:hover {
   color: inherit;
 }
 
+.marketing-page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(48px, 10vw, 96px);
+}
+
+.marketing-hero {
+  padding: clamp(72px, 12vw, 120px) 0 clamp(32px, 8vw, 64px);
+  background: linear-gradient(180deg, rgba(19, 23, 34, 0.9) 0%, rgba(19, 23, 34, 0.4) 100%);
+}
+
+.marketing-hero__title {
+  margin: 18px 0 12px;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+  color: var(--tv-heading);
+  max-width: 720px;
+}
+
+.marketing-hero__sub {
+  margin: 0 0 28px;
+  max-width: 620px;
+  color: var(--tv-muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.marketing-hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.marketing-section {
+  padding: 0 0 clamp(24px, 6vw, 56px);
+}
+
+.marketing-section--cta .landing-cta-box {
+  align-items: flex-start;
+}
+
+.design-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 900px) {
+  .design-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.backtests-page {
+  padding: clamp(72px, 12vw, 120px) 0;
+}
+
+.backtests-header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+@media (min-width: 900px) {
+  .backtests-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.backtests-header h1 {
+  margin: 12px 0 8px;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+}
+
+.backtests-header p {
+  margin: 0;
+  color: var(--tv-muted);
+  max-width: 560px;
+  line-height: 1.6;
+}
+
+.backtests-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.backtests-toolbar input[type="search"] {
+  flex: 1 1 260px;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(11, 15, 26, 0.9);
+  color: var(--tv-heading);
+}
+
+.backtests-toolbar__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.backtests-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 900px) {
+  .backtests-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.backtest-card {
+  border-radius: var(--tv-radius);
+  background: rgba(19, 23, 34, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--tv-shadow);
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+}
+
+.backtest-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.backtest-card__title {
+  display: flex;
+  gap: 12px;
+}
+
+.backtest-card__title input[type="checkbox"] {
+  margin-top: 6px;
+  width: 18px;
+  height: 18px;
+}
+
+.backtest-card__title a {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.backtest-card__title p {
+  margin: 2px 0 0;
+  color: var(--tv-muted);
+  font-size: 0.95rem;
+}
+
+.backtest-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: var(--tv-muted);
+}
+
+.backtest-card__metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.backtest-card__metrics dt {
+  font-size: 0.8rem;
+  color: var(--tv-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.backtest-card__metrics dd {
+  margin: 4px 0 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.backtest-card footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.backtest-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.comparison-panel {
+  margin-top: 48px;
+  border-radius: var(--tv-radius);
+  background: rgba(10, 12, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--tv-shadow);
+  padding: 28px;
+  display: grid;
+  gap: 20px;
+}
+
+.comparison-header h2 {
+  margin: 0 0 6px;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.comparison-header p {
+  margin: 0;
+  color: var(--tv-muted);
+}
+
+.comparison-table {
+  display: grid;
+  gap: 12px;
+}
+
+.comparison-table__row {
+  display: grid;
+  gap: 12px;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.comparison-table__row--head {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--tv-muted);
+}
+
+.comparison-table__label {
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.strategy-page {
+  padding: clamp(72px, 12vw, 120px) 0;
+}
+
+.strategy-header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+@media (min-width: 900px) {
+  .strategy-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.strategy-header h1 {
+  margin: 12px 0 8px;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+}
+
+.strategy-header p {
+  margin: 0;
+  color: var(--tv-muted);
+}
+
+.strategy-metrics {
+  margin-top: 40px;
+  display: grid;
+  gap: 20px;
+}
+
+.strategy-metrics__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 900px) {
+  .strategy-metrics__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.strategy-metrics h2,
+.strategy-notes h2,
+.strategy-trades h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.strategy-notes {
+  margin-top: 40px;
+  background: rgba(10, 12, 19, 0.85);
+  border-radius: var(--tv-radius);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 24px;
+  color: var(--tv-muted);
+  line-height: 1.6;
+}
+
+.strategy-trades {
+  margin-top: 40px;
+  display: grid;
+  gap: 16px;
+}
+
+.strategy-trades__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (min-width: 900px) {
+  .strategy-trades__heading {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.strategy-trades__heading p {
+  margin: 4px 0 0;
+  color: var(--tv-muted);
+}
+
+.strategy-trades__totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  color: var(--tv-muted);
+  font-size: 0.95rem;
+}
+
+.pricing-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 900px) {
+  .pricing-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.plan-card {
+  border-radius: var(--tv-radius);
+  background: rgba(19, 23, 34, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--tv-shadow);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.plan-card__badge {
+  align-self: flex-start;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(41, 98, 255, 0.16);
+  color: var(--tv-heading);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.plan-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+}
+
+.plan-card__price {
+  margin: -8px 0 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+}
+
+.plan-card__price span {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--tv-muted);
+  font-weight: 500;
+}
+
+.plan-card__description {
+  margin: 0;
+  color: var(--tv-muted);
+  line-height: 1.6;
+}
+
+.plan-card ul {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 10px;
+  color: var(--tv-muted);
+}
+
+.plan-card__cta {
+  margin-top: auto;
+}
+
+.roadmap-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 20px;
+}
+
+.roadmap-item {
+  border-radius: var(--tv-radius);
+  background: rgba(19, 23, 34, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--tv-shadow);
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.roadmap-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.9rem;
+  color: var(--tv-muted);
+}
+
+.roadmap-item__badge {
+  padding: 4px 12px;
+  border-radius: var(--radius-full);
+  background: rgba(41, 98, 255, 0.14);
+  color: var(--tv-heading);
+  font-weight: 600;
+}
+
+.roadmap-item__status {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.roadmap-item h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.roadmap-item p {
+  margin: 0;
+  color: var(--tv-muted);
+  line-height: 1.6;
+}
+
+.roadmap-item--complete .roadmap-item__status {
+  color: #34d399;
+}
+
+.roadmap-item--in-progress .roadmap-item__status {
+  color: #fbbf24;
+}
+
+.roadmap-item--up-next .roadmap-item__status,
+.roadmap-item--planned .roadmap-item__status {
+  color: rgba(209, 212, 220, 0.7);
+}
+
 .landing-section {
   padding: clamp(56px, 10vw, 96px) 0;
+}
+
+.auth-page {
+  padding: clamp(72px, 12vw, 120px) 0;
+}
+
+.auth-card {
+  max-width: 520px;
+  margin: 0 auto;
+  border-radius: var(--tv-radius);
+  background: rgba(19, 23, 34, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--tv-shadow);
+  padding: 40px;
+  display: grid;
+  gap: 18px;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+}
+
+.auth-card p {
+  margin: 0;
+  color: var(--tv-muted);
+  line-height: 1.6;
+}
+
+.auth-form {
+  display: grid;
+  gap: 16px;
+}
+
+.feedback-card {
+  max-width: 640px;
+}
+
+.feedback-form {
+  display: grid;
+  gap: 18px;
+}
+
+.feedback-form textarea {
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(11, 15, 26, 0.9);
+  color: var(--tv-heading);
+  font-size: 1rem;
+  resize: vertical;
+}
+
+.feedback-form textarea:focus,
+.feedback-form input[type="range"]:focus {
+  outline: none;
+  border-color: rgba(64, 149, 255, 0.9);
+  box-shadow: 0 0 0 3px rgba(41, 98, 255, 0.25);
+}
+
+.auth-form label {
+  display: grid;
+  gap: 6px;
+  color: var(--tv-muted);
+  font-size: 0.95rem;
+}
+
+.auth-form input,
+.auth-form select {
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(11, 15, 26, 0.9);
+  color: var(--tv-heading);
+  font-size: 1rem;
+}
+
+.auth-form input:focus,
+.auth-form select:focus {
+  outline: none;
+  border-color: rgba(64, 149, 255, 0.9);
+  box-shadow: 0 0 0 3px rgba(41, 98, 255, 0.25);
+}
+
+.auth-switch {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--tv-muted);
+}
+
+.auth-switch a {
+  color: var(--tv-heading);
+}
+
+.auth-switch a:hover {
+  color: var(--tv-accent);
 }
 
 .landing-container {
@@ -91,8 +1028,31 @@ a:hover {
 
 .landing-hero {
   padding: clamp(80px, 12vw, 120px) 0 clamp(64px, 10vw, 96px);
-  text-align: center;
   background: linear-gradient(180deg, rgba(30, 34, 45, 0.8) 0%, rgba(19, 23, 34, 0.1) 60%, transparent 100%);
+}
+
+.landing-hero__layout {
+  display: grid;
+  gap: 36px;
+  align-items: center;
+}
+
+@media (min-width: 960px) {
+  .landing-hero__layout {
+    grid-template-columns: 1fr 0.9fr;
+  }
+}
+
+.landing-hero__content {
+  text-align: left;
+}
+
+.landing-hero__panel {
+  border-radius: var(--tv-radius);
+  background: rgba(24, 29, 41, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--tv-shadow);
+  padding: 28px;
 }
 
 .landing-hero-title {
@@ -105,11 +1065,17 @@ a:hover {
 }
 
 .landing-hero-sub {
-  margin: 0 auto 28px;
-  max-width: 720px;
+  margin: 0 0 28px;
+  max-width: 620px;
   font-size: 1.05rem;
   line-height: 1.6;
   color: var(--tv-muted);
+}
+
+.landing-hero-note {
+  margin-top: 18px;
+  font-size: 0.85rem;
+  color: rgba(209, 212, 220, 0.75);
 }
 
 .landing-badge {
@@ -130,6 +1096,51 @@ a:hover {
   flex-wrap: wrap;
   justify-content: center;
   gap: 12px;
+}
+
+@media (min-width: 720px) {
+  .landing-hero-cta {
+    justify-content: flex-start;
+  }
+}
+
+.landing-highlight-grid {
+  margin: clamp(40px, 8vw, 64px) auto 0;
+  width: min(100%, var(--tv-max-width));
+  padding: 0 24px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .landing-highlight-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.landing-highlight {
+  border-radius: var(--tv-radius);
+  background: rgba(24, 29, 41, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: center;
+}
+
+.landing-highlight .value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--tv-heading);
+}
+
+.landing-highlight .label {
+  font-size: 0.9rem;
+  color: var(--tv-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .landing-btn {
@@ -288,6 +1299,22 @@ a:hover {
   line-height: 1.6;
 }
 
+.landing-panel-title {
+  margin: 0 0 18px;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.landing-feature-list {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 0 0 24px;
+  color: var(--tv-muted);
+  display: grid;
+  gap: 12px;
+}
+
 .landing-stepper {
   list-style: none;
   padding: 0;
@@ -353,6 +1380,48 @@ a:hover {
   outline: none;
   border-color: rgba(64, 149, 255, 0.9);
   box-shadow: 0 0 0 3px rgba(41, 98, 255, 0.3);
+}
+
+.flow-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 900px) {
+  .flow-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.flow-card {
+  border-radius: var(--tv-radius);
+  background: rgba(19, 23, 34, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--tv-shadow);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.flow-card__description {
+  margin: 0;
+  color: var(--tv-muted);
+  line-height: 1.6;
+}
+
+.flow-card__steps {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+  color: var(--tv-heading);
+}
+
+.flow-card__steps li {
+  line-height: 1.6;
+  color: var(--tv-muted);
 }
 
 .landing-cta-strip {
@@ -424,6 +1493,39 @@ a:hover {
 }
 
 .landing-testimonial-placeholder {
+  color: var(--tv-muted);
+  line-height: 1.6;
+}
+
+.faq-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 960px) {
+  .faq-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.faq-card {
+  border-radius: var(--tv-radius);
+  background: rgba(19, 23, 34, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--tv-shadow);
+  padding: 24px;
+}
+
+.faq-card h3 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--tv-heading);
+}
+
+.faq-card p {
+  margin: 0;
   color: var(--tv-muted);
   line-height: 1.6;
 }

--- a/docs/multi-symbol-portfolio-backtesting-plan.md
+++ b/docs/multi-symbol-portfolio-backtesting-plan.md
@@ -1,0 +1,171 @@
+# Multi-Symbol Portfolio Backtesting SaaS: Full Lifecycle Plan
+
+## 1. Discovery and Scoping
+
+### Problem: TradingView's Single-Symbol Limitation
+TradingView's Strategy Tester only evaluates one symbol per run. Power users must manually run Pine scripts symbol-by-symbol, export CSVs, and consolidate results in spreadsheets or custom scripts. This process is slow and error-prone, leaving traders without reliable portfolio-level analytics despite the existence of community-built workarounds that are difficult to maintain and limited in scope.
+
+### Target Personas and Motivations
+- **Retail Quant Hobbyist** – Tech-savvy hobbyist who wants multi-symbol validation without heavy coding.
+- **Prop Challenge Trader** – Active trader managing diversified portfolios for prop firm evaluations.
+- **Pine Script Developer** – Experienced Pine engineer needing scale and credibility for commercial strategies.
+
+### Core Jobs to Be Done
+- **Batch Backtesting**: Run the same strategy across dozens of symbols and years of data in a single job.
+- **Portfolio Simulation**: Produce consolidated equity curves and risk metrics for strategy portfolios.
+- **Rapid Iteration**: Re-run portfolio tests instantly after parameter tweaks.
+- **Cross-Strategy Comparison**: Benchmark multiple strategies across identical symbol sets.
+
+### Emotional Jobs
+Confidence in deployment, significant time savings, professionalism, and risk mitigation through deeper test coverage.
+
+### MVP Scope
+**In Scope:** CSV ingestion from TradingView exports, aggregated performance metrics, equity curve visualization, multi-strategy imports, authenticated dashboard, configurable allocation assumptions, and basic comparisons.
+
+**Out of Scope:** Native Pine execution, live trading, strategy editors, advanced portfolio analytics (e.g., walk-forward, Monte Carlo), tick-level intraday processing, and bundled market data feeds.
+
+### Assumptions and Risks
+- **Data Availability:** Relies on user-exported TradingView CSVs; potential ToS ambiguity.
+- **User Trust:** Requires strong security posture to overcome fear of strategy leakage.
+- **Accuracy Expectations:** Aggregation math must be bulletproof to retain credibility.
+- **Performance and Cost:** Need efficient compute for large jobs without inflating infrastructure spend.
+- **User Inertia:** Product must dramatically improve UX versus spreadsheets and alternative platforms.
+- **Competitive Response:** TradingView or rivals may close the gap; speed to market and UX differentiation are critical.
+
+### 12-Week MVP Roadmap
+1. **Week 1 – Foundations:** Finalize specs, design schema, bootstrap repos, CI, and skeleton services.
+2. **Week 2 – Design Sprint:** Produce wireframes, test with early users, iterate UX direction.
+3. **Week 3 – Frontend Kickoff:** Build marketing site shell, auth screens, and isolated CSV upload prototype.
+4. **Week 4 – Backend Core:** Implement CSV parsing, trade aggregation, and metric computation end-to-end locally.
+5. **Week 5 – Dashboard UI:** Deliver authenticated dashboard with equity chart, metric cards, and trade table.
+6. **Week 6 – Alpha Testing:** Invite early adopters, gather feedback, resolve parsing/calculation bugs.
+7. **Week 7 – Hardening:** Address auth edge cases, validation, error states, and performance optimizations.
+8. **Week 8 – UX Enhancements:** Add comparison tools, demo data mode, and pricing awareness elements.
+9. **Week 9 – Marketing Prep:** Finalize homepage copy, pricing layout, analytics tracking.
+10. **Week 10 – Payments & Beta Dry Run:** Integrate Stripe, execute full workflow test on staging.
+11. **Week 11 – QA & Release Candidate:** Comprehensive testing, bug bash, deploy v0.1 behind invites.
+12. **Week 12 – Beta Release:** Expand beta cohort, monitor telemetry, collect testimonials, prep for GA.
+
+### Success Metrics
+- **Qualitative:** User delight quotes, perceived accuracy, organic referrals.
+- **Quantitative:** >50% Day-1/Week-1 retention, 5+ backtests per active user, >95% successful job completion, 5–10% free-to-paid conversion, 500+ MAU post-launch, NPS > 50.
+
+## 2. Information Architecture & UX Flows
+
+### Route Structure (JSON Sitemap)
+```json
+{
+  "publicRoutes": ["/", "/features", "/pricing", "/signup", "/login"],
+  "authRoutes": ["/dashboard", "/backtests", "/strategy/:id", "/upload", "/feedback", "/roadmap"]
+}
+```
+
+### Primary UX Flows
+1. **Onboarding → Import CSV → Run Backtest → View Results**
+   - Sign up, land on empty dashboard with upload CTA.
+   - Launch upload modal, drop multiple TradingView CSVs, validate client-side.
+   - Submit files, track processing status, transition to results view.
+   - Review equity chart, key metric cards, combined trade table; proceed to iterate or compare.
+
+2. **Strategy Comparison Across Symbols**
+   - From backtests list, select multiple runs.
+   - Open comparison view with overlaid equity curves and side-by-side metrics.
+   - Toggle metrics, derive insights, return to dashboard or duplicate tests.
+
+3. **Subscription Upgrade Flow**
+   - Access pricing page or in-app prompt, choose plan.
+   - Redirect through Stripe Checkout, confirm payment.
+   - Return to dashboard with upgraded entitlements and billing management options.
+
+Consistent navigation (sidebar + top nav), accessible components, and responsive layouts underpin each flow.
+
+## 3. Content Strategy & Conversion Copy
+
+### Hero Messaging
+- **Headline:** “Backtest Entire Portfolios in One Click – Finally, a strategy tester for TradingView power-users.”
+- **Subheadline:** “Tired of running your strategy one symbol at a time? Our cloud platform crunches 20+ symbols in seconds, so you can find the edge in your portfolio and act now – no coding or waiting required.”
+
+### Key Benefits
+1. Save hours every week through automation of CSV aggregation.
+2. Boost strategy confidence with multi-market validation insights.
+3. Enjoy a no-code experience tailored for TradingView workflows.
+4. Access institutional-grade metrics and visualizations instantly.
+
+### Calls to Action
+- **Primary:** “Try on Demo Data” – immediate preview without signup.
+- **Secondary:** “Upload Your First CSV” – direct path to core value.
+
+### FAQ Highlights
+Addresses questions on Pine Script requirements, coding prerequisites, data security, competitive differentiation, pricing tiers, and performance expectations.
+
+## 4. Visual Design System
+
+### Design Tokens (tokens.css)
+```css
+:root {
+  --color-primary: #3B82F6;
+  --color-primary-dark: #1E40AF;
+  --color-neutral-900: #111111;
+  --color-neutral-100: #F3F4F6;
+  --color-success: #16A34A;
+  --color-warning: #F59E0B;
+  --color-danger:  #DC2626;
+
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 16px;
+  --spacing-4: 32px;
+  --spacing-5: 64px;
+
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.2rem;
+  --font-size-xl: 1.44rem;
+  --font-size-2xl: 1.728rem;
+  --font-size-3xl: 2.074rem;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.1);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+  --shadow-lg: 0 10px 20px rgba(0,0,0,0.15);
+
+  --transition-default: 0.3s ease-in-out;
+  --transition-fast: 0.2s ease-in-out;
+}
+```
+
+### Base Typography
+```css
+body {
+  font-size: var(--font-size-base);
+  color: var(--color-neutral-900);
+  font-family: 'Inter', sans-serif;
+  line-height: 1.5;
+  background: #FFFFFF;
+}
+```
+
+### Component Primitives (BEM Naming)
+```css
+.button { /* base styles */ }
+.button--primary { background: var(--color-primary); color: #FFFFFF; }
+.button--outline { background: transparent; border: 2px solid var(--color-primary); }
+
+.tag { border-radius: var(--radius-full); padding: var(--spacing-1) var(--spacing-2); }
+.tag--success { background: var(--color-success); color: #fff; }
+
+.alert { padding: var(--spacing-2) var(--spacing-3); border-radius: var(--radius-sm); }
+.alert--success { background: var(--color-success); color: #fff; }
+
+.card { background: #FFFFFF; border: 1px solid var(--color-neutral-100); border-radius: var(--radius-md); }
+.card__header { font-size: var(--font-size-lg); font-weight: 600; }
+
+.modal { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; }
+.modal__dialog { max-width: 500px; background: #FFFFFF; border-radius: var(--radius-md); }
+```
+
+These tokens and primitives ensure accessible contrast, consistent spacing, modern typography, and modular component composition across the product. They also enable future theming (e.g., dark mode) via variable overrides.


### PR DESCRIPTION
## Summary
- add persistent site navigation and footer with expanded design tokens to support marketing layouts
- revamp the landing page and add dedicated features, pricing, signup/login, feedback, and roadmap views aligned to the lifecycle plan
- implement interactive demo backtests and strategy detail pages powered by mock portfolio data for comparison workflows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1620cd90832980aafb3917736866