### PR TITLE
Fix web Dockerfile openssl dependency

### DIFF
--- a/infra/Dockerfile.web
+++ b/infra/Dockerfile.web
@@ -5,7 +5,7 @@ RUN npm install
 
 FROM node:18-alpine AS builder
 WORKDIR /app
-RUN apk add --no-cache openssl1.1-compat
+RUN apk add --no-cache openssl
 COPY --from=deps /app/node_modules ./node_modules
 COPY app .
 COPY prisma ./prisma
@@ -13,7 +13,7 @@ RUN npx prisma generate && npm run build
 
 FROM node:18-alpine AS runner
 WORKDIR /app
-RUN apk add --no-cache openssl1.1-compat
+RUN apk add --no-cache openssl
 ENV NODE_ENV=production
 COPY --from=builder /app .
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- replace the deprecated openssl1.1-compat package with the current openssl package in the web Dockerfile to align with the newer Alpine base image

## Testing
- docker compose build web *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf858e5d188329a088d36772414b19